### PR TITLE
[Bug] loguru의 색상이 Kubernetes 환경에서 정상적으로 출력되지 않음

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,4 +173,3 @@ cython_debug/
 # Credentials
 local.env
 prod.env
-k8s/configmap.yaml

--- a/envs/test.env
+++ b/envs/test.env
@@ -1,4 +1,5 @@
 # PORT=
+LOGURU_FORMAT="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <fg #800a0a>{name}</fg #800a0a>:<fg #800a0a>{function}</fg #800a0a>:<fg #800a0a>{line}</fg #800a0a> - <level>{message}</level>"
 
 PROJECT_NAME="💨 Zerohertz's FastAPI Boilerplate 💨 (test)"
 PREFIX="/api"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fastapi-prod-env
+data:
+  prod.env: |
+    # PORT=""
+    PROJECT_NAME="💨 Zerohertz's FastAPI Boilerplate 💨 (prod)"
+    PREFIX=""
+  LOGURU_FORMAT: "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <fg #800a0a>{name}</fg #800a0a>:<fg #800a0a>{function}</fg #800a0a>:<fg #800a0a>{line}</fg #800a0a> - <level>{message}</level>"

--- a/k8s/fastapi.yaml
+++ b/k8s/fastapi.yaml
@@ -15,6 +15,12 @@ spec:
       containers:
         - name: fastapi
           image: zerohertzkr/fastapi-boilerplate:bdfae2a30822956601101c99b97cfb6c98ac008c
+          env:
+            - name: LOGURU_FORMAT
+              valueFrom:
+                configMapKeyRef:
+                  name: fastapi-prod-env
+                  key: LOGURU_FORMAT
           ports:
             - name: http
               containerPort: 8000
@@ -25,6 +31,9 @@ spec:
         - name: fastapi-prod-env-volume
           configMap:
             name: fastapi-prod-env
+            items:
+              - key: prod.env
+                path: prod.env
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
#### What type of PR is this?

- [ ] feat
- [X] fix
- [ ] refactor
- [ ] test
- [X] infra
- [ ] ci/cd
- [ ] docs
- [X] chore

#### What this PR does / why we need it

`kubectl logs` 또는 `k9s`를 통해 로그를 조회할 때 색상이 포함되지 않는 이슈 해결

#### Which issue(s) this PR fixes

Fixes #9

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation

```docs

```
